### PR TITLE
docs(cita-web-debugger): fix typo of 'about://extension' to 'chrome:/…

### DIFF
--- a/docs/zh-CN/cita-web-debugger.md
+++ b/docs/zh-CN/cita-web-debugger.md
@@ -43,7 +43,7 @@ yarn install && yarn run build
 
 ## 开启 Chrome 的开发者模式
 
-在 Chrome 中前往 `about://extension` 并开启 `Developer Mode`
+在 Chrome 中前往 `chrome://extensions` 并开启 `Developer Mode`
 
 ## 添加开发者版本的安装包
 

--- a/packages/cita-web-debugger/README.md
+++ b/packages/cita-web-debugger/README.md
@@ -45,7 +45,7 @@ yarn install && yarn run build
 
 ## Turn on Chrome Developer Mode
 
-Go to `about://extension` in chrome and turn on the switch of `Developer Mode`
+Go to `chrome://extensions` in chrome and turn on the switch of `Developer Mode`
 
 ## Add Develop Package of CITAWebDebugger
 


### PR DESCRIPTION
…/extensions'[skip ci]