### PR TITLE
add libs

### DIFF
--- a/packages/cita-signer/package.json
+++ b/packages/cita-signer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cryptape/cita-signer",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "main": "lib/index.js",
   "private": false,
   "repository": "https://github.com/cryptape/cita-sdk-js/tree/master/packages/cita-signer",


### PR DESCRIPTION
add lib,in order to use in cita-truffle-box.cita-truffle-box need the cita-sdk-js for smart contract deploying, without lib documents it won't work, and they cannot be built since sdk is a dependency