### PR TITLE
fix(changelog): update node version to 10 in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 sudo: true
 node_js:
-  - '9.4.0'
+  - '10.16.3'
 cache:
   directories:
     - /*/**/node_modules


### PR DESCRIPTION
travis logs: error get-caller-file@2.0.5: The engine "node" is
incompatible with this module. Expected version "6.* || 8.* || >= 10.*".
Got "9.4.0"
error Found incompatible module