### PR TITLE
Release v1.0.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,4 @@ subscription
 # package-lock.json
 yarn.lock
 lib
-
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,37 +1,12 @@
+# [v1.0.1](https://github.com/cryptape/cita-sdk-js/releases/tag/@cryptape/cita-sdk@1.0.1)
+
+### Changed
+bump version for early withdrawn the cita-sdk v1.0.0,  can't release the v1.0.0 to npmjs.com any more. 
+
 # [v1.0.0](https://github.com/cryptape/cita-sdk-js/releases/tag/@cryptape/cita-sdk@1.0.0)
 
-
-### Bug Fixes
-
-* fix bug of pass private key without 0x to nervos.appchain.accounts.privateKeyToAccount ([2d5d545](https://github.com/cryptape/cita-sdk-js/commit/2d5d545df12aa229e04b4a6daf75b8a3eb903e90))
-* fix chain manage contract address ([12b4558](https://github.com/cryptape/cita-sdk-js/commit/12b4558dbc6ead33f59f777cf1312ca50a8df43d))
-* fix hex to bytes ([2c0fb1b](https://github.com/cryptape/cita-sdk-js/commit/2c0fb1b9f546f2f26055d7b1856c0a99f45f96f3))
-* fix neuron web address error text ([c1cb96d](https://github.com/cryptape/cita-sdk-js/commit/c1cb96dc181b0b5a53c282b4e39cc6c8b79d75d0))
-* fix quota in test ([e328ef8](https://github.com/cryptape/cita-sdk-js/commit/e328ef8c669552c029dc814bcde59e303a0785b6))
-* fix setProvider ([f093aa9](https://github.com/cryptape/cita-sdk-js/commit/f093aa999b2fbda1d2045978feee27a3ebaab8c5))
-* fix sign flow ([9405148](https://github.com/cryptape/cita-sdk-js/commit/9405148462331cf8efb21de7f7f6c3c3202e6724))
-* fix test for 0.17 fix ([097b823](https://github.com/cryptape/cita-sdk-js/commit/097b82368f71de2fab08427ad7c191877927f4f7))
-* fix travis cache ([75b3068](https://github.com/cryptape/cita-sdk-js/commit/75b3068fc9257fad557dd39a63b16e3203f3ee03))
-* **contract:** update contract subscription methods ([a9d5939](https://github.com/cryptape/cita-sdk-js/commit/a9d59390c3f2ca430c86b268325091411c489ffc))
-* **signer:** padding result of bytes2hex with 0 ([d58286b](https://github.com/cryptape/cita-sdk-js/commit/d58286b2f10417089bf5b2a806a2ee64354c0034))
-* ignore event signature in getLogs method ([e0eef49](https://github.com/cryptape/cita-sdk-js/commit/e0eef499bb7b73032f9616b4d830f1667c44ce08))
-* update test cases ([0e28e78](https://github.com/cryptape/cita-sdk-js/commit/0e28e786ee96aa53ab366fdc9a56c3f4211cd3b4))
-
-
 ### Features
-
 * support SM2 signature and SM3 hash ([a94cd999](https://github.com/cryptape/cita-sdk-js/pull/222))
-* add log on debugger ready ([a82ec1d](https://github.com/cryptape/cita-sdk-js/commit/a82ec1d4ffab37a47bde361b2b8f21fea2477d3a))
-* update web3 deps ([b4f6460](https://github.com/cryptape/cita-sdk-js/commit/b4f6460ad9b1d527ea5f420c551ada0414039341))
-* **rpc:** add two rpc methods ([0aa093e](https://github.com/cryptape/cita-sdk-js/commit/0aa093e2228a88b84524bc62d131228a67cd3dbe))
-* **signer:** support cita v2 ([1dfae4d](https://github.com/cryptape/cita-sdk-js/commit/1dfae4d6929508966ced54fcb2d5762ac75b63dd))
-* **signer:** update cita-proto ([5ac68dc](https://github.com/cryptape/cita-sdk-js/commit/5ac68dc3f5c4b6842894aea0e54ff7b3750e75ae))
-
-
-### Performance Improvements
-
-* update neuron-web start time ([8b42137](https://github.com/cryptape/cita-sdk-js/commit/8b421373ef2afe5bd0bb44d52881fbfde27cd04d))
-
 
 
 # [v0.25.0](https://github.com/cryptape/cita-sdk-js/releases/tag/@cryptape/cita-sdk@0.25.0) ([compare](https://github.com/cryptape/cita-sdk-js/compare/@cryptape/cita-sdk@0.24.1...@cryptape/cita-sdk@0.25.0))

--- a/packages/cita-sdk/package-lock.json
+++ b/packages/cita-sdk/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@cryptape/cita-sdk",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/cita-sdk/package.json
+++ b/packages/cita-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cryptape/cita-sdk",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "lib/index.js",
   "repository": "https://github.com/cryptape/cita-sdk-js/tree/master/packages/cita-sdk",
   "author": "Keith <keithwhisper@gmail.com>",

--- a/packages/cita-web-debugger/package-lock.json
+++ b/packages/cita-web-debugger/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cita-web-debugger",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/cita-web-debugger/package.json
+++ b/packages/cita-web-debugger/package.json
@@ -1,10 +1,10 @@
 {
   "name": "cita-web-debugger",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": false,
   "license": "MIT",
   "dependencies": {
-    "@cryptape/cita-sdk": "^1.0.0",
+    "@cryptape/cita-sdk": "^1.0.1",
     "@material-ui/core": "4.3.3",
     "@material-ui/icons": "4.5.1",
     "react": "^16.4.2",


### PR DESCRIPTION
# [v1.0.1](https://github.com/cryptape/cita-sdk-js/releases/tag/@cryptape/cita-sdk@1.0.1)

### Changed
bump version for early withdrawn the cita-sdk v1.0.0,  can't release the v1.0.0 to npmjs.com any more. 